### PR TITLE
Support bind() in socket.connect().

### DIFF
--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -426,6 +426,8 @@ field & type:default & description\\\hline
 
 .path & string:nil & UNIX domain socket path \\
 
+.bind & string:nil & IP address \\
+
 .family & number & protocol family---AF\_INET (default), AF\_INET6, AF\_UNIX (default if .path specified)\\
 
 .type & number & protocol type---SOCK\_STREAM (default) or SOCK\_DGRAM\\

--- a/src/socket.c
+++ b/src/socket.c
@@ -479,8 +479,6 @@ static mode_t lso_checkperm(lua_State *L, int index) {
 static struct so_options lso_checkopts(lua_State *L, int index) {
 	struct so_options opts = *so_opts();
 
-	/* TODO: Parse .sa_bind */
-
 	if (lso_altfield(L, index, "mode", "sun_mode")) {
 		opts.sun_mode = S_IFSOCK | lso_checkperm(L, -1);
 		lua_pop(L, 1);
@@ -705,10 +703,13 @@ static lso_error_t lso_prepsocket(struct luasocket *S) {
 static lso_nargs_t lso_connect2(lua_State *L) {
 	const char *host NOTUSED = NULL, *port NOTUSED = NULL;
 	const char *path = NULL;
+	const char *bind = NULL;
 	struct so_options opts;
 	struct luasocket *S;
+	union sockaddr_any ip;
 	size_t plen;
 	int family, type, error;
+
 
 	if (lua_istable(L, 1)) {
 		opts = lso_checkopts(L, 1);
@@ -729,6 +730,12 @@ static lso_nargs_t lso_connect2(lua_State *L) {
 			host = luaL_checkstring(L, -1);
 			lua_getfield(L, 1, "port");
 			port = luaL_checkstring(L, -1);
+		}
+
+		if (lso_getfield(L, 1, "bind")) {
+			bind = luaL_checkstring(L, -1);
+			if (!(opts.sa_bind = sa_pton(&ip, sizeof(ip), bind, NULL, &error)))
+				goto error;
 		}
 	} else {
 		opts = *so_opts();


### PR DESCRIPTION
Fixes #31.

I added it to lso_connect2, not lso_checkopts. I think this is the right place because I need somewhere to store the sockaddr.

Tested it and it works.