### PR TITLE
Non-string error objects result in a 'corrupt' error

### DIFF
--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1323,7 +1323,7 @@ static void err_checktype(lua_State *L, int index, int type) {
 		err_corrupt(L, index, lua_typename(L, type));
 } /* err_checktype() */
 
-static const char *err_pushstring(lua_State *L, struct callinfo *I) {
+static const char *err_pushvalue(lua_State *L, struct callinfo *I) {
 	if (I->error.string) {
 		lua_pushvalue(L, I->error.string);
 	} else {
@@ -1331,14 +1331,14 @@ static const char *err_pushstring(lua_State *L, struct callinfo *I) {
 	}
 
 	return lua_tostring(L, -1);
-} /* err_pushstring() */
+} /* err_pushvalue() */
 
 static cqs_nargs_t err_pushinfo(lua_State *L, struct callinfo *I) {
 	int nargs = 0;
 
 	luaL_checkstack(L, 5, NULL);
 
-	err_pushstring(L, I);
+	err_pushvalue(L, I);
 	nargs = 1;
 
 	if (I->error.code) {
@@ -1371,7 +1371,7 @@ static cqs_nargs_t err_pushinfo(lua_State *L, struct callinfo *I) {
 } /* err_pushinfo() */
 
 static void err_error(lua_State *L, struct callinfo *I) {
-	err_pushstring(L, I);
+	err_pushvalue(L, I);
 	lua_error(L);
 } /* err_error() */
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1325,7 +1325,6 @@ static void err_checktype(lua_State *L, int index, int type) {
 
 static const char *err_pushstring(lua_State *L, struct callinfo *I) {
 	if (I->error.string) {
-		err_checktype(L, I->error.string, LUA_TSTRING);
 		lua_pushvalue(L, I->error.string);
 	} else {
 		lua_pushstring(L, "no error message");


### PR DESCRIPTION
Non-string error objects result in an internal 'corrupt' error
Example:
```lua
local cq = require "cqueues".new()
cq:wrap(function()
	error({message = "my error object"})
end)
print(cq:step())
```
```
lua: /usr/share/lua/5.3/cqueues.lua:83: corrupt error stack: expected string, got table at index 4
stack traceback:
	[C]: in upvalue 'step'
	/usr/share/lua/5.3/cqueues.lua:83: in method 'step'
	regress/non-string-errors.lua:5: in main chunk
	[C]: in ?
```
Fixing it is as simple as removing this check:
```diff
diff --git a/src/cqueues.c b/src/cqueues.c
index 18625f2..956fe3e 100644
--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1325,7 +1325,6 @@ static void err_checktype(lua_State *L, int index, int type) {
 
 static const char *err_pushstring(lua_State *L, struct callinfo *I) {
        if (I->error.string) {
-               err_checktype(L, I->error.string, LUA_TSTRING);
                lua_pushvalue(L, I->error.string);
        } else {
                lua_pushstring(L, "no error message");
```
But perhaps a renaming of fields/functions should be done at the same time.