### PR TITLE
:accept doesn't take options

### DIFF
--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -540,8 +540,10 @@ Wait for socket binding to succeed. You do not need to wait before proceeding to
 
 Socket binding may not occur immediately if you provided a host address that required DNS resolution over the network. This is uncommon for listening sockets but supported nonetheless; the symmetry simplifies internal code. Also, socket object instantiation with \fn{socket.listen} and \fn{socket.connect} only return errors regarding user data object construction; address lookup and binding errors are detected later, when initiated by subsequent method calls.
 
-\subsubsection[\fn{socket:accept}]{\fn{socket:accept([timeout])}}
+\subsubsection[\fn{socket:accept}]{\fn{socket:accept([options] [, timeout])}}
 Wait for and return an incoming client socket on a listening object.
+
+Optionally takes a table of named arguments. See also \fn{socket.connect\{\}}.
 
 \subsubsection[\fn{socket:clients}]{\fn{socket:clients([timeout])}}
 Iterator over \method{socket:accept}: \texttt{for con in srv:clients() do ... end}.

--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -545,7 +545,7 @@ Wait for and return an incoming client socket on a listening object.
 
 Optionally takes a table of named arguments. See also \fn{socket.connect\{\}}.
 
-\subsubsection[\fn{socket:clients}]{\fn{socket:clients([timeout])}}
+\subsubsection[\fn{socket:clients}]{\fn{socket:clients([options] [, timeout])}}
 Iterator over \method{socket:accept}: \texttt{for con in srv:clients() do ... end}.
 
 %\subsection[\fn{socket:certify}]{\fn{socket:certify(certificate)}}

--- a/src/socket.c
+++ b/src/socket.c
@@ -2666,12 +2666,18 @@ static lso_nargs_t lso_accept(lua_State *L) {
 	struct so_options opts;
 	int fd, error;
 
+	if (lua_istable(L, 2)) {
+		opts = lso_checkopts(L, 2);
+	} else {
+		opts = *so_opts();
+	}
+
 	so_clear(A->socket);
 
 	if (-1 == (fd = so_accept(A->socket, 0, 0, &error)))
 		goto error;
 
-	if ((error = cqs_socket_fdopen(L, fd, so_opts())))
+	if ((error = cqs_socket_fdopen(L, fd, &opts)))
 		goto error;
 
 	return 1;


### PR DESCRIPTION
Currently, `lso_accept` uses the default options, and does not allow passing in a table of options.

I'm currently getting a 0.04 second delay between `write`ing in one process and `read`ing in another. To remove this, I need to set the `nodelay` option on the `:accept`ed socket.