### PR TITLE
Only catch yields that are prefixed with magic value

### DIFF
--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1068,8 +1068,7 @@ int luaopen__cqueues_condition(lua_State *L) {
 
 #define CQUEUE_CLASS "Continuation Queue"
 
-#define CQUEUE__POLL ((void *)&cqueue__poll)
-static const char cqueue__poll[] = "poll magic"; // signals multilevel yield
+const char *cqueue__poll = "poll magic"; // signals multilevel yield
 
 typedef int auxref_t;
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1190,7 +1190,7 @@ static void cstack_push(struct cstack *, struct stackinfo *);
 static void cstack_pop(struct cstack *);
 static _Bool cstack_isrunning(const struct cstack *, const struct cqueue *);
 
-#define CALLINFO_INITIALIZER { 0 }
+#define CALLINFO_INITIALIZER { 0, 0, { 0, 0, 0, 0, -1 } }
 
 struct callinfo {
 	cqs_index_t self; /* stack index of cqueue object */

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -2157,7 +2157,7 @@ static double cqueue_timeout_(struct cqueue *Q) {
 #if LUA_VERSION_NUM == 502
 static int cqueue_step_cont(lua_State *L) {
 #else
-static int cqueue_step_cont(lua_State *L, int status NOTUSED, lua_KContext ctx) {
+static int cqueue_step_cont(lua_State *L, int status NOTUSED, lua_KContext ctx NOTUSED) {
 #endif
 	int nargs = lua_gettop(L);
 	struct thread *T;
@@ -2167,17 +2167,9 @@ static int cqueue_step_cont(lua_State *L, int status NOTUSED, lua_KContext ctx) 
 	I.self = 1;
 	I.registry = 3;
 
-#if LUA_VERSION_NUM == 502
-	T = lua_touserdata(L, 4);
-	/* copy arguments onto resumed stack */
-	lua_xmove(L, T->L, nargs-4);
-	lua_pop(L, 1);
-#else
-	T = (struct thread*)ctx;
-	/* copy arguments onto resumed stack */
+	T = Q->yielded_thread;
+	/* move arguments onto resumed stack */
 	lua_xmove(L, T->L, nargs-3);
-#endif
-
 	Q->yielded_thread = NULL;
 
 	switch(cqueue_process(L, Q, &I, &T)) {
@@ -2185,19 +2177,10 @@ static int cqueue_step_cont(lua_State *L, int status NOTUSED, lua_KContext ctx) 
 			break;
 		case LUA_YIELD:
 			Q->yielded_thread = T;
-#if LUA_VERSION_NUM >= 503
-			/* move arguments onto 'main' stack to return them from this yield */
-			nargs = lua_gettop(T->L);
-			lua_xmove(T->L, L, nargs);
-			return lua_yieldk(L, nargs, (intptr_t)T, cqueue_step_cont);
-#elif LUA_VERSION_NUM == 502
-			/* keep thread pointer on lua stack */
-			lua_pushlightuserdata(L, T);
 			/* move arguments onto 'main' stack to return them from this yield */
 			nargs = lua_gettop(T->L);
 			lua_xmove(T->L, L, nargs);
 			return lua_yieldk(L, nargs, 0, cqueue_step_cont);
-#endif
 		default:
 			goto oops;
 		}
@@ -2246,14 +2229,7 @@ static int cqueue_step(lua_State *L) {
 			break;
 		case LUA_YIELD:
 			Q->yielded_thread = T;
-#if LUA_VERSION_NUM >= 503
-			/* move arguments onto 'main' stack to return them from this yield */
-			nargs = lua_gettop(T->L);
-			lua_xmove(T->L, L, nargs);
-			return lua_yieldk(L, nargs, (intptr_t)T, cqueue_step_cont);
-#elif LUA_VERSION_NUM == 502
-			/* keep thread pointer on lua stack */
-			lua_pushlightuserdata(L, T);
+#if LUA_VERSION_NUM >= 502
 			/* move arguments onto 'main' stack to return them from this yield */
 			nargs = lua_gettop(T->L);
 			lua_xmove(T->L, L, nargs);

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -973,6 +973,9 @@ static int cond__gc(lua_State *L) {
 static int cond_wait(lua_State *L) {
 	cond_checkself(L, 1);
 
+	lua_pushlightuserdata(L, CQUEUE__POLL);
+	lua_insert(L, 1);
+
 	return lua_yield(L, lua_gettop(L));
 } /* cond_wait() */
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -2154,8 +2154,17 @@ static double cqueue_timeout_(struct cqueue *Q) {
 
 
 static void cqueue_resume_cont(lua_State *L, struct cqueue *Q, int nargs) {
+	int index;
 	struct thread *T = Q->yielded_thread;
-	if (!T) luaL_error(L, "cqueue not yielded");
+	if (!T) {
+		luaL_error(L, "cqueue not yielded");
+		NOTREACHED;
+	}
+	index = lua_gettop(L)-nargs+1;
+	if (lua_islightuserdata(L, index) && lua_touserdata(T->L, index) == CQUEUE__POLL) {
+		luaL_error(L, "cannot resume a coroutine passing internal cqueues._POLL value as first parameter");
+		NOTREACHED;
+	}
 	/* move arguments onto resumed stack */
 	lua_xmove(L, T->L, nargs);
 	Q->yielded_thread = NULL;

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -2242,7 +2242,7 @@ static int cqueue_step(lua_State *L) {
 	Q = cqueue_enter(L, &I, 1);
 
 	if (Q->thread.current) {
-		return luaL_error(L, "cannot step yielded cqueue");
+		return luaL_error(L, "cannot step live cqueue");
 	}
 
 	if (Q->thread.count) {

--- a/src/cqueues.h
+++ b/src/cqueues.h
@@ -124,6 +124,8 @@
 #define CQS_NOTIFY "CQS Notify"
 #define CQS_CONDITION "CQS Condition"
 
+#define CQUEUE__POLL ((void *)&cqueue__poll)
+const char *cqueue__poll; // signals multilevel yield
 
 cqs_nargs_t luaopen__cqueues(lua_State *);
 

--- a/src/cqueues.lua
+++ b/src/cqueues.lua
@@ -33,14 +33,8 @@ local loader = function(loader, ...)
 	local poller
 
 	function core.poll(...)
-		local yes, main = running()
-
-		if yes then
-			if main then
-				return yield(...)
-			else
-				return yield(_POLL, ...)
-			end
+		if running() then
+			return yield(_POLL, ...)
 		else
 			local tuple
 

--- a/src/cqueues.lua
+++ b/src/cqueues.lua
@@ -84,8 +84,7 @@ local loader = function(loader, ...)
 	if _VERSION == "Lua 5.1" then
 		local function checkstep(self, ok, ...)
 			if ok == "yielded" then
-				self:set_resume(coroutine.yield(...))
-				return self:step(0)
+				return checkstep(self, self:step_resume(coroutine.yield(...)))
 			else
 				return ok, ...
 			end


### PR DESCRIPTION
Add the ability to use a normal `coroutine.yield` to yield *out* of a managed coroutine.
This required the addition of a continuation function for `cqueue_step`.

Closes #59