### PR TITLE
Add support for SOCK_SEQPACKET

### DIFF
--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -35,7 +35,7 @@
 #include <sys/types.h>   /* socklen_t mode_t in_port_t */
 #include <sys/stat.h>    /* fchmod(2) fstat(2) S_IFSOCK S_ISSOCK */
 #include <sys/select.h>  /* FD_ZERO FD_SET fd_set select(2) */
-#include <sys/socket.h>  /* AF_UNIX AF_INET AF_INET6 SO_TYPE SO_NOSIGPIPE MSG_NOSIGNAL struct sockaddr_storage socket(2) connect(2) bind(2) listen(2) accept(2) getsockname(2) getpeername(2) */
+#include <sys/socket.h>  /* AF_UNIX AF_INET AF_INET6 SO_TYPE SO_NOSIGPIPE MSG_EOR MSG_NOSIGNAL struct sockaddr_storage socket(2) connect(2) bind(2) listen(2) accept(2) getsockname(2) getpeername(2) */
 #if defined(AF_UNIX)
 #include <sys/un.h>      /* struct sockaddr_un struct unpcbid */
 #endif
@@ -2199,6 +2199,8 @@ static size_t so_syswrite(struct socket *so, const void *src, size_t len, int *e
 		if (so->opts.fd_nosigpipe)
 			flags |= MSG_NOSIGNAL;
 		#endif
+		if (so->type == SOCK_SEQPACKET)
+			flags |= MSG_EOR;
 	}
 #endif
 retry:

--- a/src/socket.c
+++ b/src/socket.c
@@ -31,7 +31,7 @@
 #include <errno.h>	/* EBADF ENOTSOCK EOPNOTSUPP EOVERFLOW EPIPE */
 
 #include <sys/types.h>
-#include <sys/socket.h>	/* AF_UNIX MSG_CMSG_CLOEXEC SOCK_CLOEXEC SOCK_DGRAM SOCK_STREAM PF_UNSPEC socketpair(2) */
+#include <sys/socket.h>	/* AF_UNIX MSG_CMSG_CLOEXEC SOCK_CLOEXEC SOCK_STREAM SOCK_SEQPACKET SOCK_DGRAM PF_UNSPEC socketpair(2) */
 #include <sys/un.h>	/* struct sockaddr_un */
 #include <unistd.h>	/* dup(2) */
 #include <fcntl.h>      /* F_DUPFD_CLOEXEC fcntl(2) */
@@ -2938,12 +2938,13 @@ static luaL_Reg lso_globals[] = {
 
 lso_nargs_t luaopen__cqueues_socket(lua_State *L) {
 	static const struct cqs_macro macros[] = {
-		{ "AF_UNSPEC",   AF_UNSPEC },
-		{ "AF_INET",     AF_INET },
-		{ "AF_INET6",    AF_INET6 },
-		{ "AF_UNIX",     AF_UNIX },
-		{ "SOCK_STREAM", SOCK_STREAM },
-		{ "SOCK_DGRAM",  SOCK_DGRAM },
+		{ "AF_UNSPEC",      AF_UNSPEC },
+		{ "AF_INET",        AF_INET },
+		{ "AF_INET6",       AF_INET6 },
+		{ "AF_UNIX",        AF_UNIX },
+		{ "SOCK_STREAM",    SOCK_STREAM },
+		{ "SOCK_SEQPACKET", SOCK_SEQPACKET },
+		{ "SOCK_DGRAM",     SOCK_DGRAM },
 	};
 
 	cqs_pushnils(L, LSO_UPVALUES); /* initial upvalues */

--- a/src/socket.c
+++ b/src/socket.c
@@ -1623,7 +1623,7 @@ static lso_error_t lso_fill(struct luasocket *S, size_t limit) {
 		if ((count = so_read(S->socket, iov.iov_base, iov.iov_len, &error))) {
 			fifo_update(&S->ibuf.fifo, count);
 
-			if (S->type == SOCK_DGRAM) {
+			if (S->type == SOCK_DGRAM || S->type == SOCK_SEQPACKET) {
 				S->ibuf.eom = 1;
 
 				return 0;


### PR DESCRIPTION
Fixes #106 

In regards to `MSG_EOR` handling, its considerably underdocumented.
The linux man page and [`write` source](http://lxr.free-electrons.com/source/net/socket.c#L814) imply it only makes sense for `SOCK_SEQPACKET` types; so that's what I did.