### PR TITLE
src/socket.c: Distinguish invalid headers from eof.

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -109,8 +109,11 @@ static size_t iov_eoh(const struct iovec *iov, _Bool eof, int flags, int *_error
 	while (p < pe && mime_isblank(*p))
 		p++;
 
-	if (p < pe && *p != ':')
-		return 0; /* not a valid field name */
+	if (p < pe && *p != ':') {
+		/* not a valid field name */
+		error = ENOMSG;
+		goto error;
+	}
 
 	while (p < pe && (p = memchr(p, '\n', pe - p))) {
 		if (++p < pe && *p != ' ' && *p != '\t')


### PR DESCRIPTION
For some error handling, I'd like to distinguish between an invalid header vs EOF being reached.

This fix synthesizes an error code of ENOMSG, it seems the most suitable.
On my system, `strerror(ENOMSG)` is: "No message of desired type"