### PR TITLE
so_accept doesn't accept with CLOEXEC set

### DIFF
--- a/src/cqueues.h
+++ b/src/cqueues.h
@@ -64,14 +64,20 @@
 
 #define GNUC_PREREQ(M, m) (defined __GNUC__ && ((__GNUC__ > M) || (__GNUC__ == M && __GNUC_MINOR__ >= m)))
 
+#ifndef NETBSD_PREREQ
 #define NETBSD_PREREQ(M, m) __NetBSD_Prereq__(M, m, 0)
+#endif
 
+#ifndef FREEBSD_PREREQ
 #define FREEBSD_PREREQ(M, m) (defined __FreeBSD_version && __FreeBSD_version >= ((M) * 100000) + ((m) * 1000))
+#endif
 
+#ifndef GLIBC_PREREQ
 #if defined __GLIBC_PREREQ
 #define GLIBC_PREREQ(M, m) (defined __GLIBC__ && __GLIBC_PREREQ(M, m) && !__UCLIBC__)
 #else
 #define GLIBC_PREREQ(M, m) 0
+#endif
 #endif
 
 #define UCLIBC_PREREQ(M, m, p) (defined __UCLIBC__ && (__UCLIBC_MAJOR__ > M || (__UCLIBC_MAJOR__ == M && __UCLIBC_MINOR__ > m) || (__UCLIBC_MAJOR__ == M && __UCLIBC_MINOR__ == m && __UCLIBC_SUBLEVEL__ >= p)))

--- a/src/lib/socket.h
+++ b/src/lib/socket.h
@@ -44,6 +44,40 @@
 
 
 /*
+ * F E A T U R E / E N V I R O N M E N T  M A C R O S
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef __NetBSD_Prereq__
+#define __NetBSD_Prereq__(M, m, p) 0
+#endif
+
+#ifndef NETBSD_PREREQ
+#define NETBSD_PREREQ(M, m) (defined __NetBSD_Prereq__ && __NetBSD_Prereq__(M, m, 0))
+#endif
+
+#ifndef FREEBSD_PREREQ
+#define FREEBSD_PREREQ(M, m) (defined __FreeBSD_version && __FreeBSD_version >= ((M) * 100000) + ((m) * 1000))
+#endif
+
+#ifndef GLIBC_PREREQ
+#if defined __GLIBC_PREREQ
+#define GLIBC_PREREQ(M, m) (defined __GLIBC__ && __GLIBC_PREREQ(M, m) && !__UCLIBC__)
+#else
+#define GLIBC_PREREQ(M, m) 0
+#endif
+#endif
+
+#ifndef HAVE_ACCEPT4
+#define HAVE_ACCEPT4 ((__linux && (!defined __GLIBC__ || GLIBC_PREREQ(2, 10))) || FREEBSD_PREREQ(10, 0))
+#endif
+
+#ifndef HAVE_PACCEPT
+#define HAVE_PACCEPT NETBSD_PREREQ(6, 0)
+#endif
+
+
+/*
  * V E R S I O N  I N T E R F A C E S
  *
  * Vendor: Entity for which versions numbers are relevant. (If forking


### PR DESCRIPTION
`so_accept` doesn't accept with the `CLOEXEC` flag set (it only fixes it up later via `fcntl`). This can result in undesirable behaviour in multi threaded programs that spawn children.

Fixing this will require the use of `accept4`.

Options:
  - Always use `SOCK_CLOEXEC`
  - Use the `CLOEXEC` status of the "master" socket
  - Add `flags` argument for `so_accept`

Potential issues:
  - win32 semantics (doesn't have `accept4`)
  - backwards compatibility (can be solved with a `#define`)