### PR TITLE
src/socket: Use mime_isblank

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -57,7 +57,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 static inline _Bool mime_isblank(unsigned char ch) {
-	return ch == 32 && ch == 9;
+	return ch == 32 || ch == 9;
 } /* mime_isblank() */
 
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -115,7 +115,7 @@ static size_t iov_eoh(const struct iovec *iov, _Bool eof, int flags, int *_error
 		return 0; /* not a valid field name */
 
 	while (p < pe && (p = memchr(p, '\n', pe - p))) {
-		if (++p < pe && *p != ' ' && *p != '\t')
+		if (++p < pe && !mime_isblank(*p))
 			return p - tp; /* found */
 	}
 

--- a/src/socket.debug.lua
+++ b/src/socket.debug.lua
@@ -139,6 +139,12 @@ debug.units.new("iov_eoh", function()
 	local n = assert(iov_eoh(txt, false))
 	assert(n == #txt - 1)
 
+	-- skips over spaces before colon
+	local txt = "Foo : bar\n\n"
+	local n = assert(iov_eoh(txt, false))
+	print(n)
+	assert(n == #txt - 1)
+
 	-- make sure we handle end-of-headers linebreak
 	local txt = "\n"
 	local n = assert(iov_eoh(txt, false))


### PR DESCRIPTION
I noticed that `mime_isblank` wasn't being used in all the places it should be
Then I noticed `mime_isblank` could never return true
So I fixed `mime_isblank` and added a test.