### PR TITLE
Porting work for OpenSSL 1.1.0

### DIFF
--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -2413,7 +2413,7 @@ static void bio_methods_init(void) {
 	if (type == -1)
 		return;
 
-	bio_methods = BIO_meth_new(type|BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR, "struct socket*");
+	bio_methods = BIO_meth_new(type|BIO_TYPE_SOURCE_SINK, "struct socket*");
 	if (bio_methods == NULL)
 		return;
 

--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -2404,8 +2404,10 @@ static BIO_METHOD* so_get_bio_methods() {
 	return &bio_methods;
 } /* so_get_bio_methods() */
 #else
-static CRYPTO_ONCE bio_methods_init_once = CRYPTO_ONCE_STATIC_INIT;
 static BIO_METHOD* bio_methods = NULL;
+
+static CRYPTO_ONCE bio_methods_init_once = CRYPTO_ONCE_STATIC_INIT;
+
 static void bio_methods_init(void) {
 	int type = BIO_get_new_index();
 	if (type == -1)
@@ -2421,13 +2423,12 @@ static void bio_methods_init(void) {
 	BIO_meth_set_ctrl(bio_methods, bio_ctrl);
 	BIO_meth_set_create(bio_methods, bio_create);
 	BIO_meth_set_destroy(bio_methods, bio_destroy);
-}
+} /* bio_methods_init() */
+
 static BIO_METHOD* so_get_bio_methods() {
-	if (bio_methods != NULL)
-		return bio_methods;
-
-	CRYPTO_THREAD_run_once(&bio_methods_init_once, bio_methods_init);
-
+	if (bio_methods == NULL) {
+		CRYPTO_THREAD_run_once(&bio_methods_init_once, bio_methods_init);
+	}
 	return bio_methods;
 } /* so_get_bio_methods() */
 #endif

--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -2343,7 +2343,6 @@ static long bio_ctrl(BIO *bio, int cmd, long udata_i, void *udata_p) {
 		 */
 		BIO *udata = udata_p;
 		udata->init = 0;
-		udata->num = 0;
 		udata->ptr = NULL;
 
 		return 1;
@@ -2364,7 +2363,6 @@ static long bio_ctrl(BIO *bio, int cmd, long udata_i, void *udata_p) {
 static int bio_create(BIO *bio) {
 	bio->init = 0;
 	bio->shutdown = 0;
-	bio->num = 0;
 	bio->ptr = NULL;
 
 	return 1;
@@ -2373,7 +2371,6 @@ static int bio_create(BIO *bio) {
 static int bio_destroy(BIO *bio) {
 	bio->init = 0;
 	bio->shutdown = 0;
-	bio->num = 0;
 	bio->ptr = NULL;
 
 	return 1;

--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -58,7 +58,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
-#if OPENSSL_VERSION_NUMBER < 0x10100001L
+#if OPENSSL_VERSION_NUMBER < 0x10100001L || defined(LIBRESSL_VERSION_NUMBER)
 #undef BIO_ctrl_set_connected
 #define BIO_ctrl_set_connected(b, peer) (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SET_CONNECTED, 0, (char *)peer)
 #define BIO_set_init(bio, val) ((void)((bio)->init = (val)))
@@ -2386,7 +2386,7 @@ static int bio_destroy(BIO *bio) {
 	return 1;
 } /* bio_destroy() */
 
-#if OPENSSL_VERSION_NUMBER < 0x10100001L
+#if OPENSSL_VERSION_NUMBER < 0x10100001L || defined(LIBRESSL_VERSION_NUMBER)
 static BIO_METHOD bio_methods = {
 	BIO_TYPE_SOURCE_SINK,
 	"struct socket*",

--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -2400,16 +2400,16 @@ static BIO_METHOD bio_methods = {
 	NULL,
 };
 
-static BIO_METHOD* get_bio_methods() {
+static BIO_METHOD* so_get_bio_methods() {
 	return &bio_methods;
-} /* get_bio_methods() */
+} /* so_get_bio_methods() */
 #else
 CRYPTO_RWLOCK *bio_methods_lock = NULL;
 static CRYPTO_ONCE bio_methods_init = CRYPTO_ONCE_STATIC_INIT;
 static void bio_methods_lock_init(void) {
 	bio_methods_lock = CRYPTO_THREAD_lock_new();
 }
-static BIO_METHOD* get_bio_methods() {
+static BIO_METHOD* so_get_bio_methods() {
 	static BIO_METHOD *bio_methods = NULL;
 	int type;
 
@@ -2444,12 +2444,12 @@ cleanup:
 	CRYPTO_THREAD_unlock(bio_methods_lock);
 
 	return bio_methods;
-} /* get_bio_methods() */
+} /* so_get_bio_methods() */
 #endif
 
 static BIO *so_newbio(struct socket *so, int *error) {
 	BIO *bio;
-	BIO_METHOD *bio_methods = get_bio_methods();
+	BIO_METHOD *bio_methods = so_get_bio_methods();
 
 	if (bio_methods == NULL || !(bio = BIO_new(bio_methods))) {
 		*error = SO_EOPENSSL;

--- a/src/socket.c
+++ b/src/socket.c
@@ -40,7 +40,7 @@
 #include <arpa/inet.h>	/* ntohs(3) */
 
 #include <openssl/ssl.h> /* SSL_CTX, SSL_CTX_free(), SSL_CTX_up_ref(), SSL, SSL_up_ref() */
-#if OPENSSL_VERSION_NUMBER < 0x10100001L
+#if OPENSSL_VERSION_NUMBER < 0x10100001L || defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/crypto.h> /* CRYPTO_LOCK_SSL CRYPTO_add() */
 #define SSL_CTX_up_ref(ctx) CRYPTO_add(&(ctx)->references, 1, CRYPTO_LOCK_SSL_CTX)
 #define SSL_up_ref(ssl) CRYPTO_add(&(ssl)->references, 1, CRYPTO_LOCK_SSL)


### PR DESCRIPTION
For #160 

One issue remains: the auto-sensing of client vs server mode based on `SSL_METHOD`'s `ssl_connect` member.
This doesn't seem to have a workable solution, as the induction was incorrect in the first place: a given `SSL_CTX` can be for clients, servers, or both ==> the client/server flag should be passed out of band (as it is in luasec, see #136).