### PR TITLE
src/socket.c: Refactor lso_accept() to not use cqs_socket_fdopen

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -2719,8 +2719,6 @@ static lso_nargs_t lso_accept(lua_State *L) {
 		goto error;
 
 	return 1;
-syerr:
-	error = errno;
 error:
 	cqs_closefd(&fd);
 	lua_pushnil(L);


### PR DESCRIPTION
Fixes #168