### PR TITLE
src/socket.lua: Remove dead code in socket:checktls()

### DIFF
--- a/src/socket.lua
+++ b/src/socket.lua
@@ -312,19 +312,10 @@ end)
 --
 -- Smarter socket:checktls
 --
-local havessl, whynossl
-
 local _checktls; _checktls = socket.interpose("checktls", function(self)
+	local havessl, whynossl = pcall(require, "openssl.ssl")
 	if not havessl then
-		if havessl == false then
-			return nil, whynossl
-		end
-
-		local havessl, whynossl = pcall(require, "openssl.ssl")
-
-		if not havessl then
-			return nil, whynossl
-		end
+		return nil, whynossl
 	end
 
 	return _checktls(self)


### PR DESCRIPTION
The inner code previously redeclared the same locals, shadowing the upvalues.

This commit takes out the redundant code rather than removing the shadowing declaration as I'd like to support installing luaossl while a long-running cqueues program is running and have it automatically picked up.