### PR TITLE
Allow passing SSL object to :starttls()

### DIFF
--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -2201,9 +2201,6 @@ int so_starttls(struct socket *so, const struct so_starttls *cfg) {
 			goto eossl;
 	}
 
-	SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
-	SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
-
 	if (so_isbool(cfg->accept)) {
 		so->ssl.accept = so_tobool(cfg->accept);
 	} else {
@@ -2214,6 +2211,9 @@ int so_starttls(struct socket *so, const struct so_starttls *cfg) {
 		if (!SSL_set_tlsext_host_name(ssl, so->opts.tls_sendname))
 			goto eossl;
 	}
+
+	SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+	SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
 
 	so->ssl.ctx = ssl;
 	ssl = NULL;

--- a/src/lib/socket.h
+++ b/src/lib/socket.h
@@ -554,7 +554,7 @@ int so_accept(struct socket *, struct sockaddr *, socklen_t *, int *);
 struct so_starttls {
 	SSL_METHOD *method;
 	SSL_CTX *context;
-	SSL *instance; /* TODO */
+	SSL *instance;
 
 	struct iovec pushback;
 


### PR DESCRIPTION
I'm coming up with a few scenarios where I need to set per-connection TLS settings **before** any data is sent on a connection.
With openssl lacking a `SSL_CTX_dup` to create a copy of an ssl context, I think the most preferable solution would be for `:starttls()` to be able to take an `SSL` object instead.