### PR TITLE
cq:close()

### DIFF
--- a/regress/174-cq-close.lua
+++ b/regress/174-cq-close.lua
@@ -1,0 +1,15 @@
+#!/bin/sh
+_=[[
+	. "${0%%/*}/regress.sh"
+	exec runlua "$0" "$@"
+]]
+require"regress".export".*"
+
+local cq = require"cqueues".new()
+cq:close()
+check(not pcall(cq.wrap, cq), "cqueue should not allow new threads when closed") -- previously would trigger a segfault, should now error
+
+cq:close()
+info("cq:close() was safely called a second time")
+
+say"OK"

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -2840,6 +2840,7 @@ static const luaL_Reg cqueue_methods[] = {
 	{ "pollfd",  &cqueue_pollfd },
 	{ "events",  &cqueue_events },
 	{ "timeout", &cqueue_timeout },
+	{ "close",   &cqueue__gc },
 	{ NULL,      NULL }
 }; /* cqueue_methods[] */
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1482,11 +1482,13 @@ static int cqueue_new(lua_State *L) {
 
 static int cqueue__gc(lua_State *L) {
 	struct callinfo I;
-	struct cqueue *Q;
+	struct cqueue *Q = cqs_checkudata(L, 1, 1, CQUEUE_CLASS);
 
-	Q = cqueue_enter(L, &I, 1);
+	if (!!Q->cstack) {
+		Q = cqueue_enter(L, &I, 1);
 
-	cqueue_destroy(L, Q, &I);
+		cqueue_destroy(L, Q, &I);
+	}
 
 	return 0;
 } /* cqueue__gc() */

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1235,8 +1235,14 @@ struct callinfo {
 }; /* struct callinfo */
 
 
+static struct cqueue *cqueue_checkvalid(lua_State *L, int index, struct cqueue *Q) {
+	luaL_argcheck(L, !!Q->cstack, index, "cqueue closed");
+	return Q;
+} /* cqueue_checkvalid() */
+
+
 static struct cqueue *cqueue_checkself(lua_State *L, int index) {
-	return cqs_checkudata(L, index, 1, CQUEUE_CLASS);
+	return cqueue_checkvalid(L, index, cqs_checkudata(L, index, 1, CQUEUE_CLASS));
 } /* cqueue_checkself() */
 
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1940,7 +1940,9 @@ error:
 } /* cqueue_update() */
 
 
-static cqs_error_t cqueue_reboot(struct cqueue *Q, _Bool stop, _Bool restart) {
+static cqs_error_t cqueue_reboot(lua_State *L, struct cqueue *Q, _Bool stop, _Bool restart) {
+	(void)L;
+
 	if (stop) {
 		struct fileno *fileno;
 		struct thread *thread;
@@ -2439,7 +2441,7 @@ static int cqueue_reset(lua_State *L) {
 	struct cqueue *Q = cqueue_checkself(L, 1);
 	int error;
 
-	if ((error = cqueue_reboot(Q, 1, 1)))
+	if ((error = cqueue_reboot(L, Q, 1, 1)))
 		return luaL_error(L, "unable to reset continuation queue: %s", cqs_strerror(error));
 
 	return 0;
@@ -2768,11 +2770,11 @@ static int cstack_reset(lua_State *L) {
 	int error;
 
 	LIST_FOREACH(Q, &CS->cqueues, le) {
-		cqueue_reboot(Q, 1, 0);
+		cqueue_reboot(L, Q, 1, 0);
 	}
 
 	LIST_FOREACH(Q, &CS->cqueues, le) {
-		if ((error = cqueue_reboot(Q, 0, 1)))
+		if ((error = cqueue_reboot(L, Q, 0, 1)))
 			return luaL_error(L, "unable to reset continuation queue: %s", cqs_strerror(error));
 	}
 


### PR DESCRIPTION
cqueue objects should have an explicit destructor so that developers can deterministicly free up file descriptors.

Related: https://github.com/daurnimator/lua-http/issues/55