### PR TITLE
Fix some warnings

### DIFF
--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -2343,7 +2343,7 @@ static int cqueue_wrap(lua_State *L) {
 	struct callinfo I;
 	struct cqueue *Q;
 	struct lua_State *newL;
-	int top, i, error;
+	int top, error;
 
 	top = lua_gettop(L);
 
@@ -2790,7 +2790,6 @@ static int cstack_onclosefd(int *fd, void *CS) {
 static int cstack_cancel(lua_State *L) {
 	struct callinfo I = CALLINFO_INITIALIZER;
 	struct cstack *CS = cstack_self(L);
-	struct cqueue *Q;
 	int index, fd;
 
 	for (index = 1; index <= lua_gettop(L); index++) {

--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -1572,6 +1572,7 @@ static int so_starttls_(struct socket *so) {
 
 		so->ssl.state++;
 	}
+	/* FALL THROUGH */
 	case 1:
 		rval = SSL_do_handshake(so->ssl.ctx);
 
@@ -1588,6 +1589,7 @@ static int so_starttls_(struct socket *so) {
 		} /* (rval) */
 
 		so->ssl.state++;
+		/* FALL THROUGH */
 	case 2:
 		/*
 		 * NOTE: Must call SSL_get_peer_certificate() first, which
@@ -1599,6 +1601,7 @@ static int so_starttls_(struct socket *so) {
 		x509_discard(&peer);
 
 		so->ssl.state++;
+		/* FALL THROUGH */
 	case 3:
 		if (so->opts.tls_verify && !so->ssl.vrfd) {
 			error = SO_ENOTVRFD;
@@ -1607,6 +1610,7 @@ static int so_starttls_(struct socket *so) {
 		}
 
 		so->ssl.state++;
+		/* FALL THROUGH */
 	case 4:
 		break;
 	} /* switch(so->ssl.state) */

--- a/src/socket.c
+++ b/src/socket.c
@@ -2432,7 +2432,6 @@ static lso_nargs_t lso_recvfd2(lua_State *L) {
 	struct msghdr *msg;
 	struct cmsghdr *cmsg;
 	struct iovec iov;
-	struct so_options opts;
 	int fd = -1, error;
 
 	if ((error = lso_preprcv(L, S)))

--- a/src/socket.c
+++ b/src/socket.c
@@ -1699,12 +1699,10 @@ static lso_error_t lso_fill(struct luasocket *S, size_t limit) {
 				return 0;
 			}
 		} else {
-			switch (error) {
-			case EPIPE:
+			if (error == EPIPE)
 				S->ibuf.eof = 1;
-			default:
-				return error;
-			} /* switch() */
+
+			return error;
 		}
 	}
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -554,12 +554,16 @@ error:
 	switch (progress) {
 	case 4:
 		hdl_destroy(&ct->handle);
+		/* FALL THROUGH */
 	case 3:
 		pthread_attr_destroy(&ct->attr);
+		/* FALL THROUGH */
 	case 2:
 		pthread_cond_destroy(&ct->cond);
+		/* FALL THROUGH */
 	case 1:
 		pthread_mutex_destroy(&ct->mutex);
+		/* FALL THROUGH */
 	case 0:
 		break;
 	}


### PR DESCRIPTION
Seen on my local computer since installing gcc version 7.1.1 20170528

See also https://github.com/wahern/autoguess/issues/1
There are also some warnings about `-Wexpansion-to-defined` in our OpenSSL compat macros