### PR TITLE
Support luajit 2.1.0-beta3

### DIFF
--- a/src/compat52.h
+++ b/src/compat52.h
@@ -28,10 +28,12 @@
 #define LUA_OK 0
 
 
+#if !defined(luaL_newlibtable)
 static void luaL_setmetatable(lua_State *L, const char *tname) {
 	luaL_getmetatable(L, tname);
 	lua_setmetatable(L, -2);
 } /* luaL_setmetatable() */
+#endif
 
 
 static int lua_absindex(lua_State *L, int idx) {
@@ -39,6 +41,7 @@ static int lua_absindex(lua_State *L, int idx) {
 } /* lua_absindex() */
 
 
+#if !defined(luaL_newlibtable)
 static void *luaL_testudata(lua_State *L, int arg, const char *tname) {
 	void *p = lua_touserdata(L, arg);
 	int eq;
@@ -52,8 +55,9 @@ static void *luaL_testudata(lua_State *L, int arg, const char *tname) {
 
 	return (eq)? p : 0;
 } /* luaL_testudate() */
+#endif
 
-
+#if !defined(luaL_newlibtable)
 static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
 	int i, t = lua_absindex(L, -1 - nup);
 
@@ -73,7 +77,7 @@ static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
 
 #define luaL_newlib(L, l) \
 	(luaL_newlibtable((L), (l)), luaL_setfuncs((L), (l), 0))
-
+#endif
 
 static int luaL_getsubtable(lua_State *L, int index, const char *tname) {
 	lua_getfield(L, index, tname);


### PR DESCRIPTION
Closes #189

This commit fixes the following luajit specific compile error:

```
  enabling Lua 5.1
  mkdir -p /home/kenhys/work/cqueues/src/5.1
  gcc -O2 -std=gnu99 -fPIC -g -Wall -Wextra  -Wno-missing-field-initializers  -Wno-override-init -Wno-unused -O2 -fPIC -DLUA_COMPAT_APIINTCASTS -I/home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1 -D_REENTRANT -D_THREAD_SAFE -D_GNU_SOURCE -I"/usr/include" -I"/usr/include" -DCQUEUES_VENDOR='"william@25thandClement.com"' -DCQUEUES_VERSION=20161215L -DCQUEUES_COMMIT='"97cac6d16dfeefcda164e431ddd8b1956dab15b1"' -c -o /home/kenhys/work/cqueues/src/5.1/cqueues.o /home/kenhys/work/cqueues/src/cqueues.c
  In file included from /home/kenhys/work/cqueues/src/cqueues.h:44,
                 from /home/kenhys/work/cqueues/src/cqueues.c:51:
  /home/kenhys/work/cqueues/src/compat52.h:31: error: static declaration of 'luaL_setmetatable' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:92: note: previous declaration of 'luaL_setmetatable' was here
  /home/kenhys/work/cqueues/src/compat52.h:42: error: static declaration of 'luaL_testudata' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:91: note: previous declaration of 'luaL_testudata' was here
  /home/kenhys/work/cqueues/src/compat52.h:57: error: static declaration of 'luaL_setfuncs' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:88: note: previous declaration of 'luaL_setfuncs' was here
  In file included from /home/kenhys/work/cqueues/src/cqueues.h:44,
                 from /home/kenhys/work/cqueues/src/cqueues.c:51:
  /home/kenhys/work/cqueues/src/compat52.h:71:1: warning: "luaL_newlibtable" redefined
  In file included from /home/kenhys/work/cqueues/src/cqueues.c:48:
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:123:1: warning: this is the location of the previous definition
  In file included from /home/kenhys/work/cqueues/src/cqueues.h:44,
                 from /home/kenhys/work/cqueues/src/cqueues.c:51:
  /home/kenhys/work/cqueues/src/compat52.h:74:1: warning: "luaL_newlib" redefined
  In file included from /home/kenhys/work/cqueues/src/cqueues.c:48:
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:125:1: warning: this is the location of the previous definition
  make: *** [/home/kenhys/work/cqueues/src/5.1/cqueues.o] Error 1
```

Signed-off-by: Kentaro Hayashi <hayashi@cleara-code.com>