### PR TITLE
corrected socket names in example code

### DIFF
--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -1420,10 +1420,10 @@ cq:wrap(function()
 	for con in srv:clients(wait) do
 		cq:wrap(function()
 			for ln in con:lines("*L") do
-				cq:write(ln)
+				con:write(ln)
 			end
 
-			cq:shutdown("w")
+			con:shutdown("w")
 		end)
 	end
 end)


### PR DESCRIPTION
This is a minor correction to an example in `doc/cqueues.tex`.

Let me know if you want me to push a regenerated PDF file.