### PR TITLE
add thread:setname and thread:getname

### DIFF
--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -803,6 +803,14 @@ Wait for the thread to terminate. Calling the equivalent of thread.self():join()
 
 Returns a boolean and error value. If false, error value is an error code describing a local error, usually \errno{EAGAIN} or \errno{ETIMEDOUT}. If true, error value is 1) an error code describing a system error which the thread encountered, 2) an error message string returned by the new Lua instance, or 3) nil if completed successfully.
 
+\subsubsection[\fn{thread:setname}]{\fn{thread:setname(name)}}
+Set a name for the thread. The name must be a string not exceeding 15 characters in length.
+
+Returns true on success, false and an error if the name is too long.
+
+\subsubsection[\fn{thread:getname}]{\fn{thread:getname(name)}}
+Get the name of the thread. Returns the name string.
+
 \end{Module}
 
 \begin{Module}{cqueues.notify}

--- a/src/thread.c
+++ b/src/thread.c
@@ -755,6 +755,31 @@ static int ct_timeout(lua_State *L) {
 	return 0;
 } /* ct_timeout() */
 
+static int ct_setname(lua_State *L) {
+	struct cthread *ct = ct_checkthread(L, 1);
+	char  *name = luaL_checkstring(L, 2);
+	int rc = pthread_setname_np(ct->id, name);
+	if(rc == ERANGE) {
+		lua_pushboolean(L, 0);
+		lua_pushliteral(L, "thread name too long");
+		return 2;
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+} /* ct_setname() */
+
+static int ct_getname(lua_State *L) {
+	struct cthread *ct = ct_checkthread(L, 1);
+	char   buf[64];
+	int rc = pthread_getname_np(ct->id, buf, 64);
+	if(rc == ERANGE) {
+		lua_pushboolean(L, 0);
+		lua_pushliteral(L, "thread name too long");
+		return 2;
+	}
+	lua_pushstring(L, buf);
+	return 1;
+} /* ct_setname() */
 
 static int ct__eq(lua_State *L) {
 	struct cthread **a = luaL_testudata(L, 1, CQS_THREAD);
@@ -804,6 +829,8 @@ static const luaL_Reg ct_methods[] = {
 	{ "pollfd",  &ct_pollfd },
 	{ "events",  &ct_events },
 	{ "timeout", &ct_timeout },
+	{ "setname", &ct_setname },
+	{ "getname", &ct_getname },
 	{ NULL,      NULL }
 };
 


### PR DESCRIPTION
Adds wrappers for `pthread_setname_np` and `pthread_getname_np` to the thread metatable. It's quite useful to be able to name long-running threads!