### PR TITLE
mk: find cqueues version even without git on $PATH

### DIFF
--- a/mk/changelog
+++ b/mk/changelog
@@ -14,8 +14,6 @@ RELPATH=${0%/*}
 CHANGELOG=${RELPATH}/../debian/changelog
 ROOTDIR=${RELPATH}/..
 
-GIT="$(command -v git)"
-
 
 changelog() {
 	if [ ! -f ${CHANGELOG} ]; then
@@ -78,6 +76,7 @@ author)
 	'
 	;;
 commit)
+	GIT="$(command -v git)"
 	test -n "${GIT}" -a -d ${ROOTDIR}/.git || exit 1
 
 	cd ${ROOTDIR}


### PR DESCRIPTION
Fixes https://github.com/wahern/cqueues/issues/216 for me, in a simple way.  Still, I'm not really fond of weird silent fallbacks when an error happens.