### PR TITLE
Add workaround for LuaJIT not supporting >47bit pointers

### DIFF
--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -1875,7 +1875,7 @@ static void thread_add(lua_State *L, struct cqueue *Q, struct callinfo *I, int i
 	/* anchor thread context to cqueue object */
 	cqs_getuservalue(L, I->self);
 	lua_pushvalue(L, -2);
-	lua_rawsetp(L, -2, T);
+	lua_rawsetp(L, -2, CQS_UNIQUE_LIGHTUSERDATA_MASK(T));
 	lua_pop(L, 2);
 
 	LIST_INSERT_HEAD(&Q->thread.pending, T, le);
@@ -1906,7 +1906,7 @@ static void thread_del(lua_State *L, struct cqueue *Q, struct callinfo *I, struc
 	cqs_getuservalue(L, I->self);
 
 	/* set thread's uservalue (it's thread) to nil */
-	lua_rawgetp(L, -1, T);
+	lua_rawgetp(L, -1, CQS_UNIQUE_LIGHTUSERDATA_MASK(T));
 	lua_pushnil(L);
 	cqs_setuservalue(L, -2);
 	lua_pop(L, 1);
@@ -1914,7 +1914,7 @@ static void thread_del(lua_State *L, struct cqueue *Q, struct callinfo *I, struc
 
 	/* remove thread from cqueues's thread table */
 	lua_pushnil(L);
-	lua_rawsetp(L, -2, T);
+	lua_rawsetp(L, -2, CQS_UNIQUE_LIGHTUSERDATA_MASK(T));
 	lua_pop(L, 1);
 } /* thread_del() */
 
@@ -2717,7 +2717,7 @@ static struct cstack *cstack_self(lua_State *L) {
 	static const int index = 47;
 	struct cstack *CS;
 
-	lua_rawgetp(L, LUA_REGISTRYINDEX, &index);
+	lua_rawgetp(L, LUA_REGISTRYINDEX, CQS_UNIQUE_LIGHTUSERDATA_MASK(&index));
 
 	CS = lua_touserdata(L, -1);
 
@@ -2731,7 +2731,7 @@ static struct cstack *cstack_self(lua_State *L) {
 
 	LIST_INIT(&CS->cqueues);
 
-	lua_rawsetp(L, LUA_REGISTRYINDEX, &index);
+	lua_rawsetp(L, LUA_REGISTRYINDEX, CQS_UNIQUE_LIGHTUSERDATA_MASK(&index));
 
 	return CS;
 } /* cstack_self() */

--- a/src/cqueues.h
+++ b/src/cqueues.h
@@ -118,7 +118,23 @@
 #define CQS_NOTIFY "CQS Notify"
 #define CQS_CONDITION "CQS Condition"
 
-#define CQUEUE__POLL ((void *)&cqueue__poll)
+#ifndef CQS_USE_47BIT_LIGHTUSERDATA_HACK
+/* LuaJIT only supports pointers with the low 47 bits set */
+#if defined(LUA_JITLIBNAME) && (defined(_LP64) || defined(_LLP64) || defined(__arch64__) || defined (__arm64__) || defined (__aarch64__) || defined(_WIN64))
+#define CQS_USE_47BIT_LIGHTUSERDATA_HACK 1
+#else
+#define CQS_USE_47BIT_LIGHTUSERDATA_HACK 0
+#endif
+#endif
+
+#if CQS_USE_47BIT_LIGHTUSERDATA_HACK
+#define CQS_UNIQUE_LIGHTUSERDATA_MASK(p) ((void *)((intptr_t)(p) & ((1UL<<47)-1)))
+#else
+#define CQS_UNIQUE_LIGHTUSERDATA_MASK(p) ((void *)(p))
+#endif
+
+#define CQUEUE__POLL CQS_UNIQUE_LIGHTUSERDATA_MASK(&cqueue__poll)
+
 const char *cqueue__poll; // signals multilevel yield
 
 cqs_nargs_t luaopen__cqueues(lua_State *);

--- a/src/socket.c
+++ b/src/socket.c
@@ -615,11 +615,11 @@ static struct so_options lso_checkopts(lua_State *L, int index) {
 		luaL_argcheck(L, path != NULL || addr != NULL, index, "no bind address specified");
 
 		if (path) {
-			sa = lso_singleton(L, &regindex, NULL, sizeof(struct sockaddr_un));
+			sa = lso_singleton(L, CQS_UNIQUE_LIGHTUSERDATA_MASK(&regindex), NULL, sizeof(struct sockaddr_un));
 			sa->sa_family = AF_UNIX;
 			memcpy(((struct sockaddr_un*)sa)->sun_path, path, MIN(plen, sizeof(((struct sockaddr_un*)sa)->sun_path)));
 		} else {
-			sa = lso_singleton(L, &regindex, NULL, sizeof(struct sockaddr_storage));
+			sa = lso_singleton(L, CQS_UNIQUE_LIGHTUSERDATA_MASK(&regindex), NULL, sizeof(struct sockaddr_storage));
 			if (!sa_pton(sa, sizeof(struct sockaddr_storage), addr, NULL, &error))
 				luaL_argerror(L, index, lua_pushfstring(L, "%s: unable to parse bind address (%s)", addr, cqs_strerror(error)));
 
@@ -810,7 +810,7 @@ static void lso_pushmode(lua_State *L, int mode, int mask, _Bool libc) {
 static struct luasocket *lso_prototype(lua_State *L) {
 	static const int regindex;
 
-	return lso_singleton(L, &regindex, &lso_initializer, sizeof lso_initializer);
+	return lso_singleton(L, CQS_UNIQUE_LIGHTUSERDATA_MASK(&regindex), &lso_initializer, sizeof lso_initializer);
 } /* lso_prototype() */
 
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -370,7 +370,7 @@ static void *ct_enter(void *arg) {
 	*ud = ct;
 
 	lua_pushvalue(L, -1);
-	lua_rawsetp(L, LUA_REGISTRYINDEX, &selfindex);
+	lua_rawsetp(L, LUA_REGISTRYINDEX, CQS_UNIQUE_LIGHTUSERDATA_MASK(&selfindex));
 
 	if ((error = cqs_socket_fdopen(L, ct->tmp.fd[1], NULL)))
 		goto error;
@@ -797,7 +797,7 @@ static int ct_interpose(lua_State *L) {
 
 
 static int ct_self(lua_State *L) {
-	lua_rawgetp(L, LUA_REGISTRYINDEX, &selfindex);
+	lua_rawgetp(L, LUA_REGISTRYINDEX, CQS_UNIQUE_LIGHTUSERDATA_MASK(&selfindex));
 
 	return 1;
 } /* ct_self() */


### PR DESCRIPTION
Cqueues mostly uses lightuserdata as unique keys.
It's hacky, but the best workaround seems to be just masking off the top bits.

Solves #223