### PR TITLE
fix(config.h.guess) include `time.h` before checking time related def…

### DIFF
--- a/config.h.guess
+++ b/config.h.guess
@@ -536,6 +536,8 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <time.h>
+
 #ifndef HAVE_CLOCKID_T
 #ifdef CLOCK_MONOTONIC
 #define HAVE_CLOCKID_T 1


### PR DESCRIPTION
…initions. fixes #227

Tested under macOS and Fedora 29 and confirmed working.