### PR TITLE
cqueues.h: correctly declare a variable

### DIFF
--- a/src/cqueues.h
+++ b/src/cqueues.h
@@ -135,7 +135,7 @@
 
 #define CQUEUE__POLL CQS_UNIQUE_LIGHTUSERDATA_MASK(&cqueue__poll)
 
-const char *cqueue__poll; // signals multilevel yield
+extern const char *cqueue__poll; // signals multilevel yield
 
 cqs_nargs_t luaopen__cqueues(lua_State *);
 


### PR DESCRIPTION
Otherwise it gets a definition in every *.c file it gets included into.

I'm not sure why these errors never caused problems (AFAIK) until recent Fedora Rawhide.
https://kojipkgs.fedoraproject.org//work/tasks/420/41320420/build.log