### PR TITLE
add cqueues.gettime

### DIFF
--- a/doc/cqueues.tex
+++ b/doc/cqueues.tex
@@ -261,6 +261,9 @@ Return the string ``controller'' if $obj$ is a controller object, or $nil$ other
 \subsubsection[\routine{cqueues.interpose}]{\routine{cqueues.interpose(name, function)}}
 Add or interpose a \cqueues controller class method. Returns the previous method, if any.
 
+\subsubsection[\routine{cqueues.gettime}]{\routine{cqueues.gettime()}}
+Return the system's epoch time, usually clock\_gettime(CLOCK\_REALTIME).
+
 \subsubsection[\routine{cqueues.monotime}]{\routine{cqueues.monotime()}}
 Return the system's monotonic clock time, usually clock\_gettime(CLOCK\_MONOTONIC).
 

--- a/src/cqueues.c
+++ b/src/cqueues.c
@@ -295,6 +295,14 @@ static inline double tv2f(const struct timeval *tv) {
 } /* tv2f() */
 
 
+static inline double gettime(void) {
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+
+	return ts2f(&ts);
+} /* gettime() */
+
 static inline double monotime(void) {
 	struct timespec ts;
 
@@ -2708,6 +2716,13 @@ static int cqueue_interpose(lua_State *L) {
 } /* cqueue_interpose() */
 
 
+static int cqueue_gettime(lua_State *L) {
+	lua_pushnumber(L, gettime());
+
+	return 1;
+} /* cqueue_gettime() */
+
+
 static int cqueue_monotime(lua_State *L) {
 	lua_pushnumber(L, monotime());
 
@@ -2906,6 +2921,7 @@ static const luaL_Reg cqueues_globals[] = {
 	{ "create",    &cqueue_create },
 	{ "type",      &cqueue_type },
 	{ "interpose", &cqueue_interpose },
+	{ "gettime",   &cqueue_gettime },
 	{ "monotime",  &cqueue_monotime },
 	{ "cancel",    &cstack_cancel },
 	{ "reset",     &cstack_reset },


### PR DESCRIPTION
it is an equivalent of [socket.gettime](http://w3.impa.br/~diego/software/luasocket/socket.html#gettime)

```
> print(os.time())
1622826677
> print(require'cqueues'.gettime())
1622826677.2564
> 
> print(require'cqueues'.monotime())
19332.194279597
```

`gettime` returns an epoch time with ms (milli second) precision.

note: `monotime` allows to compute duration with us (micro second) precision or better.
