### PR TITLE
src/lib/socket.c: fix build with libressl >= 3.5.0

### DIFF
--- a/src/lib/socket.c
+++ b/src/lib/socket.c
@@ -135,7 +135,7 @@ int socket_v_api(void) {
 #endif
 
 #ifndef HAVE_SSL_IS_SERVER
-#define HAVE_SSL_IS_SERVER OPENSSL_PREREQ(1,1,0)
+#define HAVE_SSL_IS_SERVER (OPENSSL_PREREQ(1,1,0) || LIBRESSL_PREREQ(3,5,0))
 #endif
 
 #ifndef HAVE_SSL_UP_REF
@@ -2539,7 +2539,7 @@ static int bio_destroy(BIO *bio) {
 	return 1;
 } /* bio_destroy() */
 
-#if !OPENSSL_PREREQ(1,1,0)
+#if !OPENSSL_PREREQ(1,1,0) && !LIBRESSL_PREREQ(3,5,0)
 static BIO_METHOD bio_methods = {
 	BIO_TYPE_SOURCE_SINK,
 	"struct socket*",
@@ -2559,7 +2559,9 @@ static BIO_METHOD *so_get_bio_methods() {
 #else
 static BIO_METHOD *bio_methods = NULL;
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static CRYPTO_ONCE bio_methods_init_once = CRYPTO_ONCE_STATIC_INIT;
+#endif
 
 static void bio_methods_init(void) {
 	int type = BIO_get_new_index();
@@ -2580,7 +2582,9 @@ static void bio_methods_init(void) {
 
 static BIO_METHOD *so_get_bio_methods() {
 	if (bio_methods == NULL) {
+#ifndef LIBRESSL_VERSION_NUMBER
 		CRYPTO_THREAD_run_once(&bio_methods_init_once, bio_methods_init);
+#endif
 	}
 	return bio_methods;
 } /* so_get_bio_methods() */


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
/nvmedata/autobuild/instance-26/output-1/build/lua-cqueues-20200726/src/lib/socket.c: In function 'compat_SSL_is_server':
/nvmedata/autobuild/instance-26/output-1/build/lua-cqueues-20200726/src/lib/socket.c:188:12: error: invalid use of incomplete typedef 'SSL' {aka 'struct ssl_st'}
  188 |  return ssl->server != NULL;
      |            ^~
/nvmedata/autobuild/instance-26/output-1/build/lua-cqueues-20200726/src/lib/socket.c: At top level:
/nvmedata/autobuild/instance-26/output-1/build/lua-cqueues-20200726/src/lib/socket.c:2543:1: error: variable 'bio_methods' has initializer but incomplete type
 2543 | static BIO_METHOD bio_methods = {
      | ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/823c9e27cdb8e01a048cb751287c01c5dc70f860

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>