### PR TITLE
Allow compile for LUA >=503 without compat53

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -22,7 +22,13 @@ VENDOR_$(d) = $(or $(CQUEUES_VENDOR),$(shell $(<D)/../mk/changelog author))
 VERSION_$(d) = $(or $(CQUEUES_VERSION),$(shell $(<D)/../mk/changelog version))
 COMMIT_$(d) = $(shell $(<D)/../mk/changelog commit)
 
+ifneq ($(1), 5.3)
+ifneq ($(1), 5.4)
 CPPFLAGS_$(d) = $(ALL_CPPFLAGS) -DCOMPAT53_PREFIX=cqueues
+else
+CPPFLAGS_$(d) = $(ALL_CPPFLAGS)
+endif
+endif
 CFLAGS_$(d) = $(ALL_CFLAGS)
 SOFLAGS_$(d) = $(ALL_SOFLAGS)
 LDFLAGS_$(d) = $(ALL_LDFLAGS)
@@ -50,9 +56,17 @@ define BUILD_$(d)
 $$(d)/$(1)/cqueues.so: $$(addprefix $$(d)/$(1)/, $$(OBJS_$(d))) $$(d)/lib/libnonlua.a
 	$$(CC) -o $$@ $$^ $$(SOFLAGS_$$(abspath $$(@D)/..)) $$(LDFLAGS_$$(abspath $$(@D)/..)) $$(LIBS_$$(abspath $$(@D)/..))
 
+ifneq ($(1), 5.3)
+ifneq ($(1), 5.4)
 $$(d)/$(1)/%.o: $$(d)/%.c $$(d)/cqueues.h $$(d)/../vendor/compat53/c-api/compat-5.3.h $$(d)/config.h
 	$$(MKDIR) -p $$(@D)
 	$$(CC) $$(CFLAGS_$$(<D)) $$(ALL_LUA$(subst .,,$(1))_CPPFLAGS) $$(CPPFLAGS_$$(<D)) -c -o $$@ $$<
+else
+$$(d)/$(1)/%.o: $$(d)/%.c $$(d)/cqueues.h $$(d)/config.h
+	$$(MKDIR) -p $$(@D)
+	$$(CC) $$(CFLAGS_$$(<D)) $$(ALL_LUA$(subst .,,$(1))_CPPFLAGS) $$(CPPFLAGS_$$(<D)) -c -o $$@ $$<
+endif
+endif
 
 $$(d)/$(1)/cqueues.o: $$(d)/lib/llrb.h
 

--- a/src/cqueues.h
+++ b/src/cqueues.h
@@ -40,7 +40,9 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+#if LUA_VERSION_NUM < 503
 #include "../vendor/compat53/c-api/compat-5.3.h"
+#endif
 
 
 /*
@@ -645,5 +647,14 @@ syerr:
 	SAY("%d: %s", fd, strerror(errno));
 } /* cqs_debugfd() */
 
+/* From compat-5.3.h to compile without compat53 if >= 503
+ * helper macro for defining continuation functions (for every version
+ *  * *except* Lua 5.2) */
+#if LUA_VERSION_NUM >= 503
+#ifndef LUA_KFUNCTION
+#define LUA_KFUNCTION(_name) \
+  static int (_name)(lua_State *L, int status, lua_KContext ctx)
+#endif
+#endif
 
 #endif /* CQUEUES_H */


### PR DESCRIPTION
Compilation fails without compat53 for LUA >=503.

The adding of define for LUA_KFUNCTION from compat-5.3.h fixes it.

The purpose of that PR is to be able to package cqueues without dependency on a compat53 package for LUA >= 503.

See build.log :
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:813:1: error: return type defaults to ‘int’ [-W
> implicit-int]
>   813 | LUA_KFUNCTION(auxlib_tostringk) {
>       | ^~~~~~~~~~~~~
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c: In function ‘LUA_KFUNCTION’:
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:813:1: error: type of ‘auxlib_tostringk’ defaul
> ts to ‘int’ [-Wimplicit-int]
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:814:31: error: ‘L’ undeclared (first use in this function)
>   814 |         if (luaL_getmetafield(L, 1, "__tostring")) {
>       |                               ^
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:814:31: note: each undeclared identifier is reported only once for each function it appears in
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c: In function ‘auxlib_tostring’:
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:829:40: error: ‘auxlib_tostringk’ undeclared (first use in this function); did you mean ‘auxlib_tostring’?
>   829 |                 lua_callk(L, 1, 1, 0, &auxlib_tostringk);  
>       |                                        ^~~~~~~~~~~~~~~~
>       |                                        auxlib_tostring
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:831:24: error: implicit declaration of function ‘auxlib_tostringk’; did you mean ‘auxlib_tostring’? [-Wimplicit-function-declaration]
>   831 |                 return auxlib_tostringk(L, LUA_OK, 0);
>       |                        ^~~~~~~~~~~~~~~~
>       |                        auxlib_tostring
> mkdir -p /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/5.4
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c: At top level:
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2210:1: error: return type defaults to ‘int’ [-Wimplicit-int]
>  2210 | LUA_KFUNCTION(cqueue_step_cont) {
>       | ^~~~~~~~~~~~~
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2210:1: error: redefinition of ‘LUA_KFUNCTION’
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:813:1: note: previous definition of ‘LUA_KFUNCTION’ with type ‘int()’
>   813 | LUA_KFUNCTION(auxlib_tostringk) {
>       | ^~~~~~~~~~~~~
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c: In function ‘LUA_KFUNCTION’:
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2210:1: error: type of ‘cqueue_step_cont’ defaults to ‘int’ [-Wimplicit-int]
>  2210 | LUA_KFUNCTION(cqueue_step_cont) {
>       | ^~~~~~~~~~~~~
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2214:32: error: ‘L’ undeclared (first use in this function)
>  2214 |         int nargs = lua_gettop(L);
>       |                                ^
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2241:48: error: passing argument 4 of ‘lua_yieldk’ makes pointer from integer without a cast [-Wint-conversion]   
>  2241 |                 return lua_yieldk(L, nargs, 0, cqueue_step_cont);
>       |                                                ^~~~~~~~~~~~~~~~
>       |                                                |
>       |                                                int
> In file included from /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:47:
> /usr/include/lua5.4/lua.h:310:46: note: expected ‘lua_KFunction’ {aka ‘int (*)(lua_State *, int,  long int)’} but argument is of type ‘int’
>   310 |                                lua_KFunction k);
>       |                                ~~~~~~~~~~~~~~^
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c: In function ‘cqueue_step’:
> /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/cqueues.c:2300:48: error: ‘cqueue_step_cont’ undeclared (first use in this function); did you mean ‘cqueue_step’?
>  2300 |                 return lua_yieldk(L, nargs, 0, cqueue_step_cont);
>       |                                                ^~~~~~~~~~~~~~~~
>       |                                                cqueue_step 
> make: *** [/var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/GNUmakefile:92: /var/tmp/portage/dev-lua/cqueues-20200726/work/cqueues-rel-20200726-lua5-4/src/5.4/cqueues.o] Error 1
> make: *** Waiting for unfinished jobs....

